### PR TITLE
Ignore coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+*.py,cover
 .hypothesis/
 
 # Translations
@@ -58,5 +59,5 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# IPython Notebook
 .ipynb_checkpoints


### PR DESCRIPTION
## Summary
- ignore coverage.py artifacts ending with `.py,cover`
- fix spelling of IPython in `.gitignore`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad5c86681083289f298a1174ef9e9b